### PR TITLE
CORS allow all origins for dev mode

### DIFF
--- a/src/last_report/last_report.py
+++ b/src/last_report/last_report.py
@@ -30,12 +30,12 @@ def get_cors_origin(lambda_fn_name: str) -> str:
     if "prod" in lambda_fn_name:
         return "https://api.voltage.cires-ac.mx"
     else:
-        return "http://localhost:5173"
+        return "*"
 
 
 def respond(
         status_code: int, body: list | dict | str,
-        cors_origin: str = "http://localhost:5173"
+        cors_origin: str = "*"
 ) -> dict:
     """ A response in the format that API Gateway expects.
     """

--- a/src/list_last/list_last.py
+++ b/src/list_last/list_last.py
@@ -28,12 +28,12 @@ def get_cors_origin(lambda_fn_name: str) -> str:
     if "prod" in lambda_fn_name:
         return "https://api.voltage.cires-ac.mx"
     else:
-        return "http://localhost:5173"
+        return "*"
 
 
 def respond(
         status_code: int, body: list | dict | str,
-        cors_origin: str = "http://localhost:5173"
+        cors_origin: str = "*"
 ) -> dict:
     """ A response in the format that API Gateway expects.
     """

--- a/src/list_reports/list_reports.py
+++ b/src/list_reports/list_reports.py
@@ -31,12 +31,12 @@ def get_cors_origin(lambda_fn_name: str) -> str:
     if "prod" in lambda_fn_name:
         return "https://api.voltage.cires-ac.mx"
     else:
-        return "http://localhost:5173"
+        return "*"
 
 
 def respond(
         status_code: int, body: list | dict | str,
-        cors_origin: str = "http://localhost:5173"
+        cors_origin: str = "*"
 ) -> dict:
     """ A response in the format that API Gateway expects.
     """

--- a/src/new_report/new_report.py
+++ b/src/new_report/new_report.py
@@ -32,12 +32,12 @@ def get_cors_origin(lambda_fn_name: str) -> str:
     if "prod" in lambda_fn_name:
         return "https://api.voltage.cires-ac.mx"
     else:
-        return "http://localhost:5173"
+        return "*"
 
 
 def respond(
         status_code: int, body: list | dict | str,
-        cors_origin: str = "http://localhost:5173"
+        cors_origin: str = "*"
 ) -> dict:
     """ A response in the format that API Gateway expects.
     """

--- a/src/report_counts/report_counts.py
+++ b/src/report_counts/report_counts.py
@@ -31,12 +31,12 @@ def get_cors_origin(lambda_fn_name: str) -> str:
     if "prod" in lambda_fn_name:
         return "https://api.voltage.cires-ac.mx"
     else:
-        return "http://localhost:5173"
+        return "*"
 
 
 def respond(
         status_code: int, body: list | dict | str,
-        cors_origin: str = "http://localhost:5173"
+        cors_origin: str = "*"
 ) -> dict:
     """ A response in the format that API Gateway expects.
     """


### PR DESCRIPTION
# Pull Request

## Description
Set the Access-Control-Allow-Origin header to * for development mode. This will fix CORS errors when using the frontend in development mode. 

## Changes Made
- All API enpoints return the Access-Control-Allow-Origin header with the value of "*" in dev mode.

## Additional Notes
The CORS origin for production environment will need to be updated once we have the prod API URL.


